### PR TITLE
Update hex2bin.py

### DIFF
--- a/hex2bin.py
+++ b/hex2bin.py
@@ -2,16 +2,13 @@
 
 import sys, struct
 
-data_bin = ''
+data_bin = bytearray()
 with open(sys.argv[1]) as hexdump:
-	data = hexdump.read()
-	data = data.split("\n")
-	for i in data:
-		data_hex = i[10:57].split(' ')
-		for j in data_hex:
-			data_bin += struct.pack("B", int(j, 16))
+        for line in hexdump:
+                data_hex= line[10:57].split(" ")
+                for i in data_hex:
+                        data_bin += struct.pack("B", int(i, 16))
 
 binary_file = open(sys.argv[2], "wb")
 binary_file.write(data_bin)
 binary_file.close()
-


### PR DESCRIPTION
didn't need to read the whole file at the beginning.
made it a bit more self descriptive.
binary couldn't be concatenated with "data_bin" as a string.
didn't need to separate lines manually with their \n separators. python handles lines itself.